### PR TITLE
Initial implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+Makefile
+Makefile.in
+aclocal.m4
+autom4te.cache/
+build-aux/
+config.log
+config.status
+configure
+go.eselect

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,15 @@ Makefile.in
 aclocal.m4
 autom4te.cache/
 build-aux/
+config.h
+config.h.in
 config.log
 config.status
 configure
+go
 go.eselect
+stamp-h1
+.deps/
+.dirstamp
+*.o
+*~

--- a/.gitignore
+++ b/.gitignore
@@ -9,9 +9,12 @@ config.log
 config.status
 configure
 go
+go-wrapper-tests
 go.eselect
 stamp-h1
 .deps/
 .dirstamp
+*.log
 *.o
+*.trs
 *~

--- a/Makefile.am
+++ b/Makefile.am
@@ -6,6 +6,10 @@ AM_CFLAGS = -Wall -Wextra
 bin_PROGRAMS = go
 go_SOURCES = src/wrapper.c src/common.c src/common.h
 
+# The wrapper is installed as "go", create a symlink to provide "gofmt"
+install-exec-hook:
+	cd $(DESTDIR)$(bindir) && $(LN_S) go gofmt
+
 TESTS = go-wrapper-tests
 check_PROGRAMS = go-wrapper-tests
 go_wrapper_tests_SOURCES = src/tests.c src/common.c src/common.h

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,0 +1,2 @@
+eselectdir = $(datadir)/eselect/modules
+nodist_eselect_DATA = go.eselect

--- a/Makefile.am
+++ b/Makefile.am
@@ -6,5 +6,11 @@ AM_CFLAGS = -Wall -Wextra
 bin_PROGRAMS = go
 go_SOURCES = src/wrapper.c src/common.c src/common.h
 
+TESTS = go-wrapper-tests
+check_PROGRAMS = go-wrapper-tests
+go_wrapper_tests_SOURCES = src/tests.c src/common.c src/common.h
+go_wrapper_tests_CFLAGS = $(AM_CFLAGS) $(GLIB_CFLAGS) -Werror
+go_wrapper_tests_LDADD = $(GLIB_LIBS)
+
 eselectdir = $(datadir)/eselect/modules
 nodist_eselect_DATA = go.eselect

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,2 +1,10 @@
+AM_CPPFLAGS = -I$(srcdir)/src \
+	      -DENVD='"$(sysconfdir)/env.d"' \
+	      -DLIB='"$(libdir)"'
+AM_CFLAGS = -Wall -Wextra
+
+bin_PROGRAMS = go
+go_SOURCES = src/wrapper.c src/common.c src/common.h
+
 eselectdir = $(datadir)/eselect/modules
 nodist_eselect_DATA = go.eselect

--- a/README.md
+++ b/README.md
@@ -1,0 +1,46 @@
+# eselect go
+
+Manage multiple Go versions using Gentoo's eselect.
+
+## Usage
+
+This tool is intended for use in the CoreOS SDK in order to support
+packages or architectures that cannot upgrade to the same Go version all
+at the same time. Gentoo doesn't support this use case.
+
+Go is expected to be installed to `/usr/lib/go1.5`, `/usr/lib/go1.6`,
+etc. The `go` and `gofmt` binaries `/usr/bin` are actually wrappers and
+select which version to execute based on the `EGO` environment variable,
+the selection made by `eselect go`, or the latest version found.
+
+    $ eselect go
+    Usage: eselect go <action> <options>
+
+    Standard actions:
+      help                      Display help text
+      usage                     Display usage information
+      version                   Display version information
+
+    Extra actions:
+      list                      List installed Go versions
+      set <target>              Set main active Go version
+      show                      Show main active Go version
+      update                    Switch to the latest Go version
+        --if-unset                Do not override existing selection
+        --ignore SLOT             Ignore SLOT when setting symlinks
+
+Switch the default Go version:
+
+    $ eselect go set go1.6
+    $ go version
+    go version go1.6.3 linux/amd64
+
+Override the default in the environment:
+
+    $ export EGO=go1.5
+    $ go version
+    go version go1.5.3 linux/amd64
+
+## Bugs
+
+Please use the [CoreOS issue tracker](https://github.com/coreos/bugs/issues)

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -ex
+autoreconf --force --install --symlink

--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,12 @@ AC_CONFIG_AUX_DIR([build-aux])
 
 AM_INIT_AUTOMAKE([foreign 1.13 -Wall -Wno-portability subdir-objects])
 
+AC_PROG_CC
+
+AC_USE_SYSTEM_EXTENSIONS
+
 # Create output files.
+AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_FILES([Makefile go.eselect])
 
 AC_OUTPUT

--- a/configure.ac
+++ b/configure.ac
@@ -5,6 +5,7 @@ AC_CONFIG_AUX_DIR([build-aux])
 AM_INIT_AUTOMAKE([foreign 1.13 -Wall -Wno-portability subdir-objects])
 
 AC_PROG_CC
+AC_PROG_LN_S
 
 AC_USE_SYSTEM_EXTENSIONS
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,0 +1,10 @@
+AC_PREREQ([2.69])
+AC_INIT([eselect-go],[0.0.1],[https://github.com/coreos/bugs/issues])
+AC_CONFIG_AUX_DIR([build-aux])
+
+AM_INIT_AUTOMAKE([foreign 1.13 -Wall -Wno-portability subdir-objects])
+
+# Create output files.
+AC_CONFIG_FILES([Makefile go.eselect])
+
+AC_OUTPUT

--- a/configure.ac
+++ b/configure.ac
@@ -8,6 +8,9 @@ AC_PROG_CC
 
 AC_USE_SYSTEM_EXTENSIONS
 
+# Only used for unit tests.
+AM_PATH_GLIB_2_0([2.20.0])
+
 # Create output files.
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_FILES([Makefile go.eselect])

--- a/go.eselect.in
+++ b/go.eselect.in
@@ -1,0 +1,139 @@
+# Copyright 2016 CoreOS, Inc.
+# Copyright 1999-2014 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+DESCRIPTION="Manage Go version preferences"
+VERSION="@PACKAGE_VERSION@"
+
+ENV_D_PATH="${EROOT%/}/etc/env.d"
+LIB_PATH="${EROOT%/}/usr/lib/"
+
+# Find a list of Go versions
+find_targets() {
+	local path
+
+	for path in "${LIB_PATH}"go[[:digit:]]*.[[:digit:]]*; do
+		if [[ -f "${path}/bin/go" ]]; then
+			echo "${path#${LIB_PATH}}"
+		fi
+	done
+}
+
+set_target() {
+	local target="${1}" targets=($(find_targets))
+
+	if is_number "${target}" && [[ ${target} -ge 1 ]]; then
+		target=${targets[$((${target} - 1))]}
+	fi
+
+	if ! has ${target} "${targets[@]}"; then
+		die -q "Invalid target ${target}"
+	fi
+
+	if [[ ! -d "${LIB_PATH}${target}" ]]; then
+		die -q "Target \"${1}\" doesn't appear to be valid!"
+	fi
+
+	mkdir -p "${ENV_D_PATH}/go" && \
+		echo "${target}" > "${ENV_D_PATH}/go/config" || \
+		die -q "Can't set Go version"
+}
+
+### show action ###
+
+describe_show() {
+	echo "Show main active Go version"
+}
+
+do_show() {
+	cat "${ENV_D_PATH}/go/config"
+}
+
+### list action ###
+
+describe_list() {
+	echo "List installed Go versions"
+}
+
+do_list() {
+	local active i targets=()
+
+	active="$(do_show)"
+	targets=($(find_targets))
+
+	write_list_start "Available Go versions:"
+	for ((i = 0; i < ${#targets[@]}; i++)); do
+		if [[ ${targets[${i}]} == ${active} ]]; then
+			targets[${i}]="$(highlight_marker "${targets[${i}]}")"
+		fi
+	done
+	write_numbered_list -m "(none found)" "${targets[@]}"
+}
+
+### set action ###
+
+describe_set() {
+	echo "Set main active Go version"
+}
+
+describe_set_parameters() {
+	echo "<target>"
+}
+
+do_set() {
+	if [[ $# -ne 1 ]]; then
+		die -q "'eselect go set' requires 1 argument"
+	else
+		set_target "${1}"
+	fi
+}
+
+### update action ###
+
+describe_update() {
+	echo "Switch to the latest Go version"
+}
+
+describe_update_options() {
+	echo "--if-unset    : Do not override existing selection"
+	echo "--ignore SLOT : Ignore SLOT when setting symlinks"
+}
+
+do_update() {
+	local if_unset="0" ignored_slots=() target targets=()
+	while [[ $# > 0 ]]; do
+		case "$1" in
+			--if-unset)
+				if_unset="1"
+				;;
+			--ignore)
+				ignored_slots+=("${2}")
+				shift;;
+			*)
+				die -q "Unrecognized argument '$1'"
+				;;
+		esac
+		shift
+	done
+
+	if [[ "${if_unset}" == "1" && -f "${ENV_D_PATH}/go/config" ]]; then
+		return
+	fi
+
+	targets=($(find_targets | sort --version-sort --reverse))
+
+	# Ignore slots
+	for slot in ${ignored_slots[@]}; do
+		targets=(${targets[@]/go${slot}/})
+	done
+
+	if [[ ${#targets[@]} -gt 0 ]]; then
+		target=${targets[0]}
+		echo "Switching to ${target}"
+		set_target "${target}"
+	else
+		die -q "No Go versions available"
+	fi
+}
+
+# vim: set ft=eselect :

--- a/src/common.c
+++ b/src/common.c
@@ -1,0 +1,136 @@
+/* Copyright (C) 2016  CoreOS,Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include "common.h"
+
+#include <dirent.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#ifndef LIB
+#define LIB "/usr/lib"
+#endif
+
+#ifndef ENVD
+#define ENVD "/etc/env.d"
+#endif
+
+/* Program name, set based on argv[0], e.g. "go" or "gofmt" */
+static char program_name[NAME_MAX + 1];
+
+/* Library path where Go can be found, e.g. "/usr/lib" */
+static char library_dir[PATH_MAX] = LIB;
+
+/* Config file written by go.eselect, e.g. "/etc/env.d/go/config" */
+static char config_file[PATH_MAX] = ENVD "/go/config";
+
+static void strxcpy(char *dest, const char *src, size_t dest_len)
+{
+	strncpy(dest, src, dest_len - 1);
+	dest[dest_len - 1] = '\0';
+}
+
+void set_program_name(const char *path)
+{
+	const char *slash = strrchr(path, '/');
+	if (slash)
+		strxcpy(program_name, slash + 1, sizeof(program_name));
+	else
+		strxcpy(program_name, path, sizeof(program_name));
+}
+
+/* Just for unit tests.  */
+void set_library_dir(const char *path)
+{
+	strxcpy(library_dir, path, sizeof(library_dir));
+}
+
+/* Just for unit tests.  */
+void set_config_file(const char *path)
+{
+	strxcpy(config_file, path, sizeof(config_file));
+}
+
+size_t program_path(char *path, const char *dir, size_t path_len)
+{
+	return snprintf(path, path_len,
+			"%s/%s/bin/%s", library_dir, dir, program_name);
+}
+
+static int filter_program(const struct dirent *dir)
+{
+	char path[PATH_MAX];
+	struct stat st;
+
+	if (dir->d_type != DT_DIR && dir->d_type != DT_UNKNOWN)
+		return 0;
+
+	program_path(path, dir->d_name, sizeof(path));
+	if (stat(path, &st) != 0)
+		return 0;
+	return S_ISREG(st.st_mode);
+}
+
+int try_latest(char *dir, size_t dir_len)
+{
+	struct dirent **namelist = NULL;
+	int n;
+
+	n = scandir(library_dir, &namelist, filter_program, versionsort);
+	if (n <= 0) {
+		free(namelist);
+		return 0;
+	}
+
+	strxcpy(dir, namelist[n - 1]->d_name, dir_len);
+	while (n--)
+		free(namelist[n]);
+	free(namelist);
+	return 1;
+}
+
+int try_config(char *dir, size_t dir_len)
+{
+	char d[NAME_MAX + 1];
+	ssize_t n;
+	int fd;
+
+	if ((fd = open(config_file, O_RDONLY | O_CLOEXEC)) < 0)
+		return 0;
+	if ((n = read(fd, d, sizeof(d) - 1)) < 0)
+		return 0;
+
+	if (d[n - 1] == '\n')
+		n--;
+	if (n == 0)
+		return 0;
+	d[n] = '\0';
+
+	strxcpy(dir, d, dir_len);
+	return 1;
+}
+
+int try_environ(char *dir, size_t dir_len)
+{
+	char *d = getenv("EGO");
+	if (!d || !strlen(d))
+		return 0;
+	strxcpy(dir, d, dir_len);
+	return 1;
+}

--- a/src/common.h
+++ b/src/common.h
@@ -1,0 +1,28 @@
+/* Copyright (C) 2016  CoreOS,Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#ifndef ESELECT_GO_COMMON_H__
+#define ESELECT_GO_COMMON_H__
+
+#include "config.h"
+#include <sys/types.h>
+
+void set_program_name(const char *path);
+void set_library_dir(const char *path);
+void set_config_file(const char *path);
+size_t program_path(char *path, const char *dir, size_t path_len);
+int try_latest(char *dir, size_t dir_len);
+int try_config(char *dir, size_t dir_len);
+int try_environ(char *dir, size_t dir_len);
+
+#endif

--- a/src/tests.c
+++ b/src/tests.c
@@ -1,0 +1,162 @@
+/* Copyright (C) 2016  CoreOS,Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include "common.h"
+
+#include <fcntl.h>
+#include <limits.h>
+#include <locale.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include <glib.h>
+
+static void test_program_path()
+{
+	char path[PATH_MAX];
+
+	set_library_dir("/fake/lib");
+	set_program_name("app1");
+	program_path(path, "dir1", sizeof(path));
+	g_assert_cmpstr(path, ==, "/fake/lib/dir1/bin/app1");
+
+	program_path(path, "dir2", sizeof(path));
+	g_assert_cmpstr(path, ==, "/fake/lib/dir2/bin/app1");
+
+	set_program_name("app2");
+	program_path(path, "dir2", sizeof(path));
+	g_assert_cmpstr(path, ==, "/fake/lib/dir2/bin/app2");
+}
+
+static void test_try_environ()
+{
+	char dir[NAME_MAX + 1];
+
+	g_assert(unsetenv("EGO") == 0);
+	g_assert(try_environ(dir, sizeof(dir)) == 0);
+	g_assert(setenv("EGO", "", 1) == 0);
+	g_assert(try_environ(dir, sizeof(dir)) == 0);
+	g_assert(setenv("EGO", "dir1", 1) == 0);
+	g_assert(try_environ(dir, sizeof(dir)) == 1);
+	g_assert_cmpstr(dir, ==, "dir1");
+	g_assert(unsetenv("EGO") == 0);
+}
+
+static void newtemp(char *tmpl)
+{
+	int fd = mkstemp(tmpl);
+	g_assert(fd >= 0);
+	g_assert(close(fd) == 0);
+}
+
+static void test_try_config()
+{
+	GError *err = NULL;
+	char tmp[] = "/tmp/wrapper-config-XXXXXX";
+	char dir[NAME_MAX + 1];
+
+	set_config_file("/this/path/does/not/exist");
+	g_assert(try_config(dir, sizeof(dir)) == 0);
+
+	newtemp(tmp);
+	set_config_file(tmp);
+	g_assert(try_config(dir, sizeof(dir)) == 0);
+
+	g_file_set_contents(tmp, "dir1\n", 5, &err);
+	g_assert_no_error(err);
+	g_assert(try_config(dir, sizeof(dir)) == 1);
+	g_assert_cmpstr(dir, ==, "dir1");
+
+	g_file_set_contents(tmp, "dir2", 4, &err);
+	g_assert_no_error(err);
+	g_assert(try_config(dir, sizeof(dir)) == 1);
+	g_assert_cmpstr(dir, ==, "dir2");
+
+	g_assert(unlink(tmp) == 0);
+}
+
+static void fakeapp(const char *lib, const char *dir, const char *app)
+{
+	char *bin = g_strconcat(lib, "/", dir, "/bin", NULL);
+	char *path = g_strconcat(bin, "/", app, NULL);
+	int fd;
+
+	g_assert(g_mkdir_with_parents(bin, 0700) == 0);
+	fd = open(path, O_WRONLY | O_CREAT | O_CLOEXEC, 0600);
+	g_assert(fd >= 0);
+	g_assert(close(fd) == 0);
+
+	g_free(bin);
+	g_free(path);
+}
+
+/* Does glib really not provide this? :-( */
+static void rmdirs(char *path)
+{
+	GError *err = NULL;
+	char *argv[] = { "rm", "-rf", path, NULL };
+	g_spawn_sync(NULL, argv, NULL, G_SPAWN_SEARCH_PATH |
+		     G_SPAWN_STDOUT_TO_DEV_NULL |
+		     G_SPAWN_STDERR_TO_DEV_NULL,
+		     NULL, NULL, NULL, NULL, NULL, &err);
+	g_assert_no_error(err);
+}
+
+static void test_try_latest()
+{
+	char tmp[] = "/tmp/wrapper-latest-XXXXXX";
+	char dir[NAME_MAX + 1];
+
+	g_assert(mkdtemp(tmp) != NULL);
+	set_library_dir(tmp);
+	set_program_name("app1");
+	g_assert(try_latest(dir, sizeof(dir)) == 0);
+
+	fakeapp(tmp, "dir1", "app1");
+	g_assert(try_latest(dir, sizeof(dir)) == 1);
+	g_assert_cmpstr(dir, ==, "dir1");
+
+	fakeapp(tmp, "dir2", "app1");
+	g_assert(try_latest(dir, sizeof(dir)) == 1);
+	g_assert_cmpstr(dir, ==, "dir2");
+
+	fakeapp(tmp, "dir3", "app2");
+	g_assert(try_latest(dir, sizeof(dir)) == 1);
+	g_assert_cmpstr(dir, ==, "dir2");
+
+	fakeapp(tmp, "dir10", "app1");
+	g_assert(try_latest(dir, sizeof(dir)) == 1);
+	g_assert_cmpstr(dir, ==, "dir10");
+
+	set_program_name("app2");
+	g_assert(try_latest(dir, sizeof(dir)) == 1);
+	g_assert_cmpstr(dir, ==, "dir3");
+
+	set_program_name("app3");
+	g_assert(try_latest(dir, sizeof(dir)) == 0);
+
+	rmdirs(tmp);
+}
+
+int main(int argc, char **argv)
+{
+	setlocale(LC_ALL, "");
+
+	g_test_init(&argc, &argv, NULL);
+	g_test_add_func("/wrapper/program_path", test_program_path);
+	g_test_add_func("/wrapper/try_environ", test_try_environ);
+	g_test_add_func("/wrapper/try_config", test_try_config);
+	g_test_add_func("/wrapper/try_latest", test_try_latest);
+
+	return g_test_run();
+}

--- a/src/wrapper.c
+++ b/src/wrapper.c
@@ -1,0 +1,37 @@
+/* Copyright (C) 2016  CoreOS,Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include "common.h"
+
+#include <limits.h>
+#include <unistd.h>
+
+/* 127 is the standard return code for "command not found" */
+#define EXIT_ERROR 127
+
+int main(int argc __attribute__ ((unused)), char **argv)
+{
+	char target_dir[NAME_MAX + 1], target_path[PATH_MAX];
+
+	set_program_name(argv[0]);
+
+	if (try_environ(target_dir, sizeof(target_dir)) ||
+	    try_config(target_dir, sizeof(target_dir)) ||
+	    try_latest(target_dir, sizeof(target_dir))) {
+		program_path(target_path, target_dir, sizeof(target_path));
+		argv[0] = target_path;
+		execv(argv[0], argv);
+	}
+
+	return EXIT_ERROR;
+}


### PR DESCRIPTION
This is modeled after eselect-python, making it easy to switch between Go versions both globally via configuration and locally at run-time via an environment variable. So ebuilds just needs to `export EGO=go1.5`  or whatever the appropriate version is and the `go` command will behave appropriately.
